### PR TITLE
Bug fixed: App.jsx "import Tops failed"

### DIFF
--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -6,7 +6,7 @@ import Summary from "./pages/Summary";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import UserContextProvider from "./components/UserContextProvider";
 import Trends from "./pages/Trends";
-import Tops from "./pages/tops";
+import Tops from "./pages/Tops";
 import Analysis from "./pages/Analysis";
 import Playlists from "./pages/Playlists";
 import Playlist from "./pages/Playlist";


### PR DESCRIPTION
Error pops up when launching the front: Failed to resolve import "./pages/tops" from "src/App.jsx" Does the file exist?

## Describe your changes
It seems the error happens because the file App.jsx tries to import "./pages/tops" but that file was called "./pages/Tops". 

I just changed the line 9 in "src/App.jsx" file to: 
**import Tops from "./pages/Tops";** and the error was fixed.

Note: My system has Ubuntu 22.04 LTS and Node v18.16.0

Some screenshots of the error:
![Screenshot from 2023-04-25 17-40-48](https://user-images.githubusercontent.com/61513467/234348266-7fe0b78a-7abf-461d-b566-4e5ad3a814ef.png)

![Screenshot from 2023-04-25 17-41-22](https://user-images.githubusercontent.com/61513467/234348353-0d36b73f-5182-4bc2-b18a-3a12ec70ff16.png)



## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have read the PULL_REQUEST_TEMPLATE as well as the CODE_OF_CONDUCT
- [ ] If it is a core feature, I have added thorough tests.